### PR TITLE
Applied ScanTimeOut

### DIFF
--- a/app/src/main/java/net/grandcentrix/blutufintegration/data/repo/BluetoothRepository.kt
+++ b/app/src/main/java/net/grandcentrix/blutufintegration/data/repo/BluetoothRepository.kt
@@ -4,7 +4,6 @@ import android.bluetooth.BluetoothAdapter
 import android.bluetooth.BluetoothManager
 import android.content.Context
 import android.util.Log
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
@@ -15,8 +14,6 @@ import net.grandcentrix.blutufintegration.data.model.DeviceUiState
 import net.grandcentrix.blutufintegration.data.model.ProcessState
 import net.grandcentrix.blutufintegration.data.model.State
 
-private const val SCAN_TIMEOUT: Long = 5000
-
 object BluetoothRepository {
 
     var isScanning = false
@@ -25,12 +22,10 @@ object BluetoothRepository {
     val selectedDeviceStateFlow = MutableStateFlow<DeviceUiState?>(null)
     val devicesStateFlow = MutableSharedFlow<ProcessState<List<DeviceUiState>>>()
 
-    @ExperimentalCoroutinesApi
     suspend fun scan() {
-        devices.clear()
         if (!isScanning) {
             isScanning = true
-
+            devices.clear()
             coroutineScope {
                 Blutuf.bleManager.startScan(
                     onDeviceAppeared = { device ->

--- a/app/src/main/java/net/grandcentrix/blutufintegration/ui/list/ListFragment.kt
+++ b/app/src/main/java/net/grandcentrix/blutufintegration/ui/list/ListFragment.kt
@@ -57,11 +57,9 @@ class ListFragment : Fragment(), DevicesAdapter.OnClickActions {
             binding.swipToRefresh.isRefreshing = false
         }
 
-        viewModel.uiModel.observe(viewLifecycleOwner, { uiModel -> updateUi(uiModel) })
-        viewModel.selectedDevice.observe(viewLifecycleOwner, { device -> updateDevice(device) })
-        viewModel.scanState.observe(
-            viewLifecycleOwner,
-            { isScanning -> updateScanState(isScanning) })
+        viewModel.uiModel.observe(viewLifecycleOwner) { uiModel -> updateUi(uiModel) }
+        viewModel.selectedDevice.observe(viewLifecycleOwner) { device -> updateDevice(device) }
+        viewModel.scanState.observe(viewLifecycleOwner) { isScanning -> updateScanState(isScanning) }
     }
 
     private fun updateDevice(device: DeviceUiState?) {

--- a/app/src/main/java/net/grandcentrix/blutufintegration/ui/list/ListFragment.kt
+++ b/app/src/main/java/net/grandcentrix/blutufintegration/ui/list/ListFragment.kt
@@ -57,15 +57,15 @@ class ListFragment : Fragment(), DevicesAdapter.OnClickActions {
             binding.swipToRefresh.isRefreshing = false
         }
 
-
         viewModel.uiModel.observe(viewLifecycleOwner, { uiModel -> updateUi(uiModel) })
         viewModel.selectedDevice.observe(viewLifecycleOwner, { device -> updateDevice(device) })
+        viewModel.scanState.observe(
+            viewLifecycleOwner,
+            { isScanning -> updateScanState(isScanning) })
     }
 
     private fun updateDevice(device: DeviceUiState?) {
         device?.let {
-            Log.e("samii"," list update state "+device.state)
-
             adapter.updateItem(device)
             binding.statusContainer.state.text = device.getStateTitle(requireContext())
         }
@@ -85,6 +85,10 @@ class ListFragment : Fragment(), DevicesAdapter.OnClickActions {
         }
     }
 
+    private fun updateScanState(isScanning: Boolean) {
+        binding.progressBar.isVisible = isScanning
+    }
+
     private fun updateUi(uiModel: ProcessState<List<DeviceUiState>>) {
         when (uiModel) {
             is ProcessState.Scanning -> {
@@ -97,7 +101,6 @@ class ListFragment : Fragment(), DevicesAdapter.OnClickActions {
                 adapter.setItems(uiModel.data)
             }
             is ProcessState.Error -> {
-
             }
         }
     }

--- a/app/src/main/java/net/grandcentrix/blutufintegration/ui/list/ListViewModel.kt
+++ b/app/src/main/java/net/grandcentrix/blutufintegration/ui/list/ListViewModel.kt
@@ -1,7 +1,8 @@
 package net.grandcentrix.blutufintegration.ui.list
 
+import android.os.Handler
+import android.os.Looper
 import androidx.lifecycle.*
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import net.grandcentrix.blutuf.core.Blutuf
@@ -10,13 +11,18 @@ import net.grandcentrix.blutuf.core.api.BlutufEventResult
 import net.grandcentrix.blutufintegration.data.model.DeviceUiState
 import net.grandcentrix.blutufintegration.data.repo.BluetoothRepository
 
+private const val SCAN_TIMEOUT: Long = 5000
+
 class ListViewModel : ViewModel() {
 
     val uiModel = BluetoothRepository.devicesStateFlow.asLiveData()
 
-    val selectedDevice: LiveData<DeviceUiState?> = BluetoothRepository.selectedDeviceStateFlow.asLiveData()
+    val selectedDevice: LiveData<DeviceUiState?> =
+        BluetoothRepository.selectedDeviceStateFlow.asLiveData()
 
     var bleStateFlow = MutableStateFlow(false)
+
+    val scanState = MutableLiveData(false)
 
     init {
         Blutuf.bleManager.registerEventListener(this::onEvent)
@@ -24,6 +30,7 @@ class ListViewModel : ViewModel() {
 
     override fun onCleared() {
         Blutuf.bleManager.unregisterEventListener(this::onEvent)
+        BluetoothRepository.stopScan()
     }
 
     private fun onEvent(event: BlutufEvent, result: BlutufEventResult) {
@@ -41,15 +48,19 @@ class ListViewModel : ViewModel() {
         }
     }
 
-    @ExperimentalCoroutinesApi
     fun startScan() {
         viewModelScope.launch {
+            scanState.value = true
             BluetoothRepository.scan()
+            Handler(Looper.getMainLooper()).postDelayed({
+                stopScan()
+            }, SCAN_TIMEOUT)
         }
     }
 
     private fun stopScan() {
         BluetoothRepository.stopScan()
+        scanState.value = false
     }
 
     fun onConnectClicked(deviceUiState: DeviceUiState) {

--- a/app/src/main/java/net/grandcentrix/blutufintegration/ui/list/ListViewModel.kt
+++ b/app/src/main/java/net/grandcentrix/blutufintegration/ui/list/ListViewModel.kt
@@ -8,18 +8,14 @@ import net.grandcentrix.blutuf.core.Blutuf
 import net.grandcentrix.blutuf.core.api.BlutufEvent
 import net.grandcentrix.blutuf.core.api.BlutufEventResult
 import net.grandcentrix.blutufintegration.data.model.DeviceUiState
-import net.grandcentrix.blutufintegration.data.model.ProcessState
 import net.grandcentrix.blutufintegration.data.repo.BluetoothRepository
 
 private const val SCAN_TIMEOUT: Long = 5000
 
 class ListViewModel : ViewModel() {
 
-    private val _uiModel = BluetoothRepository.devicesStateFlow.asLiveData()
-    val uiModel: LiveData<ProcessState<List<DeviceUiState>>> = _uiModel
-
-    private val _selectedDevice = BluetoothRepository.selectedDeviceStateFlow.asLiveData()
-    val selectedDevice: LiveData<DeviceUiState?> = _selectedDevice
+    val uiModel = BluetoothRepository.devicesStateFlow.asLiveData()
+    val selectedDevice = BluetoothRepository.selectedDeviceStateFlow.asLiveData()
 
     var bleStateFlow = MutableStateFlow(false)
 

--- a/app/src/main/java/net/grandcentrix/blutufintegration/ui/list/ListViewModel.kt
+++ b/app/src/main/java/net/grandcentrix/blutufintegration/ui/list/ListViewModel.kt
@@ -1,28 +1,30 @@
 package net.grandcentrix.blutufintegration.ui.list
 
-import android.os.Handler
-import android.os.Looper
 import androidx.lifecycle.*
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import net.grandcentrix.blutuf.core.Blutuf
 import net.grandcentrix.blutuf.core.api.BlutufEvent
 import net.grandcentrix.blutuf.core.api.BlutufEventResult
 import net.grandcentrix.blutufintegration.data.model.DeviceUiState
+import net.grandcentrix.blutufintegration.data.model.ProcessState
 import net.grandcentrix.blutufintegration.data.repo.BluetoothRepository
 
 private const val SCAN_TIMEOUT: Long = 5000
 
 class ListViewModel : ViewModel() {
 
-    val uiModel = BluetoothRepository.devicesStateFlow.asLiveData()
+    private val _uiModel = BluetoothRepository.devicesStateFlow.asLiveData()
+    val uiModel: LiveData<ProcessState<List<DeviceUiState>>> = _uiModel
 
-    val selectedDevice: LiveData<DeviceUiState?> =
-        BluetoothRepository.selectedDeviceStateFlow.asLiveData()
+    private val _selectedDevice = BluetoothRepository.selectedDeviceStateFlow.asLiveData()
+    val selectedDevice: LiveData<DeviceUiState?> = _selectedDevice
 
     var bleStateFlow = MutableStateFlow(false)
 
-    val scanState = MutableLiveData(false)
+    private val _scanState = MutableLiveData(false)
+    val scanState : LiveData<Boolean> = _scanState
 
     init {
         Blutuf.bleManager.registerEventListener(this::onEvent)
@@ -50,17 +52,16 @@ class ListViewModel : ViewModel() {
 
     fun startScan() {
         viewModelScope.launch {
-            scanState.value = true
+            _scanState.value = true
             BluetoothRepository.scan()
-            Handler(Looper.getMainLooper()).postDelayed({
-                stopScan()
-            }, SCAN_TIMEOUT)
+            delay(SCAN_TIMEOUT)
+            stopScan()
         }
     }
 
     private fun stopScan() {
         BluetoothRepository.stopScan()
-        scanState.value = false
+        _scanState.value = false
     }
 
     fun onConnectClicked(deviceUiState: DeviceUiState) {

--- a/app/src/main/res/layout/view_status_container.xml
+++ b/app/src/main/res/layout/view_status_container.xml
@@ -10,41 +10,41 @@
         android:id="@+id/icon"
         android:layout_width="24dp"
         android:layout_height="24dp"
-        android:src="@drawable/ic_ble_off"
         android:layout_marginStart="16dp"
-        app:layout_constraintTop_toTopOf="parent"
+        android:src="@drawable/ic_ble_off"
+        android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        android:visibility="gone"/>
+        app:layout_constraintTop_toTopOf="parent" />
 
     <ProgressBar
         android:id="@+id/progress_bar2"
         android:layout_width="24dp"
         android:layout_height="24dp"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
         android:layout_marginStart="16dp"
         android:indeterminateTint="@color/dark_gray"
-        android:visibility="gone"/>
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <androidx.constraintlayout.widget.Barrier
         android:id="@+id/barrier"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        app:constraint_referenced_ids="progress_bar2, icon"
-        app:barrierDirection="end"/>
+        app:barrierDirection="end"
+        app:constraint_referenced_ids="progress_bar2, icon" />
 
     <TextView
         android:id="@+id/state"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
+        android:text="Disconnected"
         android:textSize="14sp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toEndOf="@id/barrier"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:text="Disconnected" />
+        app:layout_constraintTop_toTopOf="parent" />
 
     <com.google.android.material.switchmaterial.SwitchMaterial
         android:id="@+id/switch_ble"


### PR DESCRIPTION

## Description
In order to save battery, we need timeout for scanning. It has been applied to listViewModel as the scan is called from there.
Also, the scan gets paused when ViewModel destroys. 

* a new liveData has been created in viewmodel to keep the state of scanning in order to show/hide progressbar. (maybe we can handle it in a better way?!)

Remaining stuff: prevent scan from being called multiple times. (Currently, it’s handled with a flag in BluetoothRepository)